### PR TITLE
bugfix in City.java

### DIFF
--- a/src/main/java/nagoya/code4/resas/CityResult.java
+++ b/src/main/java/nagoya/code4/resas/CityResult.java
@@ -10,7 +10,6 @@ public class CityResult implements City {
 	/* (non-Javadoc)
 	 * @see nagoya.code4.resas.City#getPrefCode()
 	 */
-	@Override
 	public String getPrefCode() {
 		return prefCode;
 	}
@@ -20,7 +19,6 @@ public class CityResult implements City {
 	/* (non-Javadoc)
 	 * @see nagoya.code4.resas.City#getCityCode()
 	 */
-	@Override
 	public String getCityCode() {
 		return cityCode;
 	}
@@ -30,7 +28,6 @@ public class CityResult implements City {
 	/* (non-Javadoc)
 	 * @see nagoya.code4.resas.City#getCityName()
 	 */
-	@Override
 	public String getCityName() {
 		return cityName;
 	}
@@ -40,7 +37,6 @@ public class CityResult implements City {
 	/* (non-Javadoc)
 	 * @see nagoya.code4.resas.City#getBigCityFlag()
 	 */
-	@Override
 	public String getBigCityFlag() {
 		return bigCityFlag;
 	}


### PR DESCRIPTION
The method getBigCityFlag() of type CityResult must override a superclass method

なんかEclipseが上記のエラーを吐くのですが、環境問題のような気も。こちらのcompiler level=1.8

Ref: http://slumbers99.blogspot.jp/2013/01/eclipse-override-must-override.html